### PR TITLE
Utilize max CPUs instead of min

### DIFF
--- a/src/lib/pageVideoStreamWriter.ts
+++ b/src/lib/pageVideoStreamWriter.ts
@@ -159,7 +159,7 @@ export default class PageVideoStreamWriter extends EventEmitter {
   }
 
   private getDestinationStream(): ffmpeg {
-    const cpu = Math.min(1, os.cpus().length);
+    const cpu = Math.max(1, os.cpus().length - 1);
     const outputStream = ffmpeg({
       source: this.videoMediatorStream,
       priority: 20,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Always uses `1`  thread

- **What is the new behavior (if this is a feature change)?**

Use `cpuCount - 1` threads.
This is preferable to using up all of a users cores in case they are trying to do anything else with their computer while running the recording.

- **Other information**:
