### PR TITLE
Remove session once the page closes

### DIFF
--- a/src/lib/PuppeteerScreenRecorder.ts
+++ b/src/lib/PuppeteerScreenRecorder.ts
@@ -60,13 +60,13 @@ export class PuppeteerScreenRecorder {
    * @ignore
    */
   private setupListeners(): void {
-    this.page.on('close', async () => await this.stop());
+    this.page.once('close', async () => await this.stop());
 
     this.streamReader.on('pageScreenFrame', (pageScreenFrame) => {
       this.streamWriter.insert(pageScreenFrame);
     });
 
-    this.streamWriter.on('videoStreamWriterError', () => this.stop());
+    this.streamWriter.once('videoStreamWriterError', () => this.stop());
   }
 
   /**

--- a/src/lib/pageVideoStreamCollector.ts
+++ b/src/lib/pageVideoStreamCollector.ts
@@ -122,6 +122,7 @@ export class pageVideoStreamCollector extends EventEmitter {
 
   public async start(): Promise<void> {
     await this.startSession(this.page);
+    this.page.once('close', async () => await this.endSession());
 
     if (this.shouldFollowPopupWindow) {
       this.addListenerOnTabOpens(this.page);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Solves issue #14 

- **What is the new behavior (if this is a feature change)?**

Add a listener for the page's close and remove associated handler once it happens
