### PR TITLE
feat: add autopad option on ffmpeg configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ const Config = {
     width: 1024,
     height: 768,
   },
+  autopad: {
+    color: 'black' | '#35A5FF',
+  },
   aspectRatio: '4:3',
 };
 ```
@@ -95,6 +98,8 @@ const Config = {
 > - **videoFrame**: An object which is to specify the width and height of the capturing video frame. Default to browser viewport size.
 
 > - **aspectRatio**: Specify the aspect ratio of the video. Default value is `4:3`.
+
+> - **autopad**: Specify whether autopad option is used and its color. Default to autopad deactivation mode.
 
 > - **recordDurationLimit**: Numerical value specify duration (in seconds) to record the video. By default video is recorded till stop method is invoked`. (Note: It's mandatory to invoke Stop() method even if this value is set)
 

--- a/src/lib/pageVideoStreamTypes.ts
+++ b/src/lib/pageVideoStreamTypes.ts
@@ -63,6 +63,15 @@ export type PuppeteerScreenRecorderOptions = {
   readonly aspectRatio?: '3:2' | '4:3' | '16:9';
 
   /**
+   * @name autopad
+   * @member PuppeteerScreenRecorderOptions
+   * @description Specify whether autopad option is used and its color. Default to autopad deactivation mode.
+   */
+  readonly autopad?: {
+    color?: string;
+  };
+
+  /**
    * @name recordDurationLimit
    * @member PuppeteerScreenRecorderOptions
    * @description  Numerical value specify duration (in seconds) to record the video. By default video is recorded till stop method is invoked`. (Note: It's mandatory to invoke Stop() method even if this value is set)

--- a/src/lib/pageVideoStreamWriter.ts
+++ b/src/lib/pageVideoStreamWriter.ts
@@ -59,6 +59,14 @@ export default class PageVideoStreamWriter extends EventEmitter {
     return width !== null && height !== null ? `${width}x${height}` : '100%';
   }
 
+  private get autopad(): { activation: boolean; color?: string } {
+    const autopad = this.options.autopad;
+
+    return !autopad
+      ? { activation: false }
+      : { activation: true, color: autopad.color };
+  }
+
   private getFfmpegPath(): string | null {
     if (this.options.ffmpeg_Path) {
       return this.options.ffmpeg_Path;
@@ -167,6 +175,7 @@ export default class PageVideoStreamWriter extends EventEmitter {
       .videoCodec('libx264')
       .size(this.videoFrameSize)
       .aspect(this.options.aspectRatio || '4:3')
+      .autopad(this.autopad.activation, this.autopad.color)
       .inputFormat('image2pipe')
       .inputFPS(this.options.fps)
       .outputOptions('-preset ultrafast')

--- a/src/lib/pageVideoStreamWriter.ts
+++ b/src/lib/pageVideoStreamWriter.ts
@@ -175,7 +175,7 @@ export default class PageVideoStreamWriter extends EventEmitter {
       .videoCodec('libx264')
       .size(this.videoFrameSize)
       .aspect(this.options.aspectRatio || '4:3')
-      .autopad(this.autopad.activation, this.autopad.color)
+      .autopad(this.autopad.activation, this.autopad?.color)
       .inputFormat('image2pipe')
       .inputFPS(this.options.fps)
       .outputOptions('-preset ultrafast')

--- a/src/spec/PuppeteerScreenRecorder.spec.ts
+++ b/src/spec/PuppeteerScreenRecorder.spec.ts
@@ -207,3 +207,97 @@ test('case 4 --> Happy Path: Should be able to create a new screen-recording ses
     assert.is(fileWriteStream.writableFinished, true);
   });
 });
+
+test('case 5a --> Happy Path: testing video recording with video frame width, height and autopad color', async (assert) => {
+  /** setup */
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const options: PuppeteerScreenRecorderOptions = {
+    followNewTab: false,
+    videoFrame: {
+      width: 1024,
+      height: 1024,
+    },
+    autopad: {
+      color: 'gray',
+    },
+  };
+  const outputVideoPath = './test-output/test/video-recorder/testCase5a.mp4';
+  const recorder = new PuppeteerScreenRecorder(page, options);
+  const recorderValue = await recorder.start(outputVideoPath);
+
+  /** execute */
+  await page.goto('https://github.com', { waitUntil: 'load' });
+  /** clear */
+  const status = await recorder.stop();
+
+  await browser.close();
+
+  /** assert */
+  assert.is(recorderValue instanceof PuppeteerScreenRecorder, true);
+  assert.is(status, true);
+  assert.is(fs.existsSync(outputVideoPath), true);
+});
+
+test('case 5b --> Happy Path: testing video recording with video frame width, height and autopad color as hex code', async (assert) => {
+  /** setup */
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const options: PuppeteerScreenRecorderOptions = {
+    followNewTab: false,
+    videoFrame: {
+      width: 1024,
+      height: 1024,
+    },
+    autopad: {
+      color: '#008000',
+    },
+  };
+  const outputVideoPath = './test-output/test/video-recorder/testCase5b.mp4';
+  const recorder = new PuppeteerScreenRecorder(page, options);
+  const recorderValue = await recorder.start(outputVideoPath);
+
+  /** execute */
+  await page.goto('https://github.com', { waitUntil: 'load' });
+  /** clear */
+  const status = await recorder.stop();
+
+  await browser.close();
+
+  /** assert */
+  assert.is(recorderValue instanceof PuppeteerScreenRecorder, true);
+  assert.is(status, true);
+  assert.is(fs.existsSync(outputVideoPath), true);
+});
+
+test('case 5c --> Happy Path: testing video recording with video frame width, height and default autopad color', async (assert) => {
+  /** setup */
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const options: PuppeteerScreenRecorderOptions = {
+    followNewTab: false,
+    videoFrame: {
+      width: 1024,
+      height: 1024,
+    },
+    autopad: {},
+  };
+  const outputVideoPath = './test-output/test/video-recorder/testCase5c.mp4';
+  const recorder = new PuppeteerScreenRecorder(page, options);
+  const recorderValue = await recorder.start(outputVideoPath);
+
+  /** execute */
+  await page.goto('https://github.com', { waitUntil: 'load' });
+  /** clear */
+  const status = await recorder.stop();
+
+  await browser.close();
+
+  /** assert */
+  assert.is(recorderValue instanceof PuppeteerScreenRecorder, true);
+  assert.is(status, true);
+  assert.is(fs.existsSync(outputVideoPath), true);
+});


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
### feature
- add an option for using [autopad](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#autopadcolorblack-enable-auto-padding-the-output-video)

## What is the current behavior? (You can also link to an open issue here)

When I record, I sometimes configure a test that changes the size of the screen. 
Even if the size of the recording area is fixed, after calls the function `Puppeteer.setViewport()`,,,
The size of the screen is magnified (I think this is perfectly normal because I fixed the size of the recording screen).

![스크린샷 2022-08-02 오후 6 42 50](https://user-images.githubusercontent.com/28749913/182344747-e1880d5f-ac38-4d6c-a8ea-7a54b0560f53.png)

## What is the new behavior (if this is a feature change)?

Adding the autopad option allows smooth recording even if the size of the area inside the recording screen changes.
**The following are the applicable:**
```.ts
public async record() {
    this.recorder = new PuppeteerScreenRecorder(this.page, {
      followNewTab: true,
      fps: 30,
      ffmpeg_Path: null,
      videoFrame: {
        width: 1200,
        height: 768,
      },
      aspectRatio: '3:2',
      autopad: {
        color: 'pink',
      },
    });
    await this.recorder.start(`./videos/${this.pageId}.mp4`);
}
```

![스크린샷 2022-08-02 오후 6 42 13](https://user-images.githubusercontent.com/28749913/182344809-71b57a5a-cea3-4ebd-b618-8d552eedce79.png)

## Other information
First of all, I would like to thank you for using your module really well. 👍 
I want to help you not only this time but also in the future.
I think the addition of a test pipeline for each function will guarantee the stability of the module.
If you're thinking about applying github actions or it, I'll help you in the future.