### PR TITLE
remove test.com from README.md as it does not load

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ const { PuppeteerScreenRecorder } = require('puppeteer-screen-recorder');
   const recorder = new PuppeteerScreenRecorder(page);
   await recorder.start('./report/video/simple.mp4'); // supports extension - mp4, avi, webm and mov
   await page.goto('https://example.com');
-
-  await page.goto('https://test.com');
   await recorder.stop();
   await browser.close();
 })();


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

change the example in README.md to not load [test.com](https://test.com), as that site does not load/exist..!

- **What is the current behavior?** (You can also link to an open issue here)

when running the example at the bottom of the README.md file, puppeteer throws a timeout exception as test.com does not load

- **What is the new behavior (if this is a feature change)?**

the example code works - puppeteer only navigates to example.com

- **Other information**:
