### PR TITLE
adding metadata option

### DIFF
--- a/src/lib/pageVideoStreamTypes.ts
+++ b/src/lib/pageVideoStreamTypes.ts
@@ -129,6 +129,13 @@ export type PuppeteerScreenRecorderOptions = {
    * @description  Numerical value specify duration (in seconds) to record the video. By default video is recorded till stop method is invoked`. (Note: It's mandatory to invoke Stop() method even if this value is set)
    */
   readonly recordDurationLimit?: number;
+
+  /**
+   * @name metadata
+   * @member PuppeteerScreenRecorderOptions
+   * @description Specify metadata information as key value pairs.
+   */
+  readonly metadata?: object
 };
 
 /** @ignore */

--- a/src/lib/pageVideoStreamWriter.ts
+++ b/src/lib/pageVideoStreamWriter.ts
@@ -187,6 +187,9 @@ export default class PageVideoStreamWriter extends EventEmitter {
       .on('progress', (progressDetails) => {
         this.duration = progressDetails.timemark;
       });
+    for(const key in this.options.metadata) {
+      outputStream.outputOptions('-metadata', `${key}=${this.options.metadata[key]}`);
+    }
 
     if (this.options.recordDurationLimit) {
       outputStream.duration(this.options.recordDurationLimit);

--- a/src/lib/pageVideoStreamWriter.ts
+++ b/src/lib/pageVideoStreamWriter.ts
@@ -29,6 +29,8 @@ export default class PageVideoStreamWriter extends EventEmitter {
   private readonly screenLimit = 10;
   private screenCastFrames = [];
   public duration = '00:00:00:00';
+  public frameGain = 0;
+  public frameLoss = 0;
 
   private status = VIDEO_WRITE_STATUS.NOT_STARTED;
   private options: VideoOptions;
@@ -274,12 +276,30 @@ export default class PageVideoStreamWriter extends EventEmitter {
   public write(data: Buffer, durationSeconds = 1): void {
     this.status = VIDEO_WRITE_STATUS.IN_PROGRESS;
 
-    const NUMBER_OF_FPS = Math.max(
-      Math.floor(durationSeconds * this.options.fps),
+    const totalFrames =  durationSeconds * this.options.fps;
+    let floored = Math.floor(totalFrames);
+
+    let numberOfFPS = Math.max(
+      floored,
       1
     );
+    if (floored === 0) {
+      this.frameGain += 1 - totalFrames;
+    } else {
+      this.frameLoss += totalFrames - floored;
+    }
 
-    for (let i = 0; i < NUMBER_OF_FPS; i++) {
+    while(1 < this.frameLoss) {
+      this.frameLoss--;
+      numberOfFPS++;
+    }
+    while(1 < this.frameGain) {
+      this.frameGain--;
+      numberOfFPS--;
+    }
+
+
+    for (let i = 0; i < numberOfFPS; i++) {
       this.videoMediatorStream.write(data);
     }
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  **feature**
   add an option for metadata

- **What is the current behavior?** (You can also link to an open issue here)
  unable to invoke outputOptions(); because ffmpeg is not accessible. Instead of making it public, I decided to add an option.
- **What is the new behavior (if this is a feature change)?**
  metadata option added so that you don't need to another ffmpeg operation for it.

```javascript
const option = {
    followNewTab: true,
    fps: 30,
    ffmpeg_Path: null,
    videoCrf: 23,
    autopad: {
      color: 'black' | '#35A5FF',
    },
    aspectRatio: '4:3',
    metadata: {
      title: 'Awesome video',
      comment: 'example comment'
    }
  };

let recorder = new PuppeteerScreenRecorder(page, option);
```
- **Other information**:
Thank you for your great work. 👍  