### PR TITLE
add ffmpegAdditionalOptions config prop. Also, improve handling of er…

### DIFF
--- a/src/lib/pageVideoStreamTypes.ts
+++ b/src/lib/pageVideoStreamTypes.ts
@@ -115,6 +115,13 @@ export type PuppeteerScreenRecorderOptions = {
   readonly videoPixelFormat?: string;
 
   /**
+   * @name ffmpegAdditionalOptions
+   * @member PuppeteerScreenRecorderOptions
+   * @description Allows you to pass additional options to the ffmpeg encoder - for example you might want to pass "-movflags +faststart"
+   */
+  readonly ffmpegAdditionalOptions?: string[];
+
+  /**
    * @name autopad
    * @member PuppeteerScreenRecorderOptions
    * @description Specify whether autopad option is used and its color. Default to autopad deactivation mode.


### PR DESCRIPTION
I wanted to add the ffmpeg option `-movflags +faststart`, as I'm generating video preview thumbnails; so I added the option to add custom options to the ffmpeg commandline.

Before, some errors from ffmpeg were being silently dropped, in particular: bad filter errors, which I noticed while testing this new feature - before, you'd just get a zero length video with no explanation. I've therefore fixed ffmpeg error handling so that it will properly catch and handle errors on stdout from ffmpeg.
If you're writing a file, you'll get ffmpeg errors to stderr. If you're writing to a stream, you can catch the error event on that stream and you will receive all ffmpeg errors. 